### PR TITLE
race condition fix

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -60,22 +60,21 @@ namespace WebSocketSharp
 
       private set
       {
-        switch (value)
-        {
-          case WsState.OPEN:
-            if (OnOpen != null)
-            {
-              OnOpen(this, EventArgs.Empty);
-            }
-            goto default;
-          case WsState.CLOSING:
-          case WsState.CLOSED:
-            close(value);
-            break;
-          default:
-            readyState = value;
-            break;
-        }
+          readyState = value;
+          switch (value)
+          {
+
+              case WsState.OPEN:
+                  if (OnOpen != null)
+                  {
+                      OnOpen(this, EventArgs.Empty);
+                  }
+                  break;
+              case WsState.CLOSING:
+              case WsState.CLOSED:
+                  close(value);
+                  break;
+          }
       }
     }
 


### PR DESCRIPTION
Fixing a 'race condition'; when sending data from an OnOpen event handler the lib would throw an exception saying the socking isn't open yet. Moving the value setter up fixes this.
