### PR TITLE
Added CustomHeaders to WebSocketClient

### DIFF
--- a/websocket-sharp/Server/WebSocketServiceHostManager.cs
+++ b/websocket-sharp/Server/WebSocketServiceHostManager.cs
@@ -703,7 +703,7 @@ namespace WebSocketSharp.Server
       if (message == null || message.Length == 0)
         return Broadping ();
 
-      byte [] data;
+      byte [] data = null;
       var msg = _state.CheckIfStarted () ??
                 (data = Encoding.UTF8.GetBytes (message)).CheckIfValidPingData ();
 

--- a/websocket-sharp/Server/WebSocketSessionManager.cs
+++ b/websocket-sharp/Server/WebSocketSessionManager.cs
@@ -601,7 +601,7 @@ namespace WebSocketSharp.Server
       if (message == null || message.Length == 0)
         return Broadping ();
 
-      byte [] data;
+      byte [] data = null;
       var msg = _state.CheckIfStarted () ??
                 (data = Encoding.UTF8.GetBytes (message)).CheckIfValidPingData ();
 

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -245,7 +245,7 @@ namespace WebSocketSharp
 
     #region Public Properties
 
-	public IEnumerable<KeyValuePair<string,string>> CustomHeaders { get; set; }
+    public IEnumerable<KeyValuePair<string,string>> CustomHeaders { get; set; }
 
     /// <summary>
     /// Gets or sets the compression method used to compress the payload data of the WebSocket Data frame.
@@ -716,13 +716,13 @@ namespace WebSocketSharp
 
       req.AddHeader ("Sec-WebSocket-Version", _version);
 
-	  if (CustomHeaders != null)
-	  {
-		  foreach (var header in CustomHeaders)
-		  {
-			  req.AddHeader(header.Key, header.Value);
-		  }
-	  }
+      if (CustomHeaders != null)
+      {
+        foreach (var header in CustomHeaders)
+        {
+          req.AddHeader(header.Key, header.Value);
+        }
+      }
 
       if (_preAuth && _credentials != null)
         req.SetAuthorization (new AuthenticationResponse (_credentials));
@@ -833,7 +833,7 @@ namespace WebSocketSharp
     {
       _readyState = WebSocketState.OPEN;
 
-	  OnOpen.Emit(this, EventArgs.Empty);
+      OnOpen.Emit(this, EventArgs.Empty);
       startReceiving ();
     }
 
@@ -1236,35 +1236,35 @@ namespace WebSocketSharp
       _stream = WsStream.CreateClientStream (_tcpClient, _secure, host, _certValidationCallback);
     }
 
-	private void startReceiving()
-	{
-		_exitReceiving = new AutoResetEvent(false);
-		_receivePong = new AutoResetEvent(false);
+    private void startReceiving()
+    {
+      _exitReceiving = new AutoResetEvent(false);
+      _receivePong = new AutoResetEvent(false);
 
-		Action receive = null;
-		receive = () => _stream.ReadFrameAsync(
-		  frame =>
-		  {
-			  if (processFrame(frame))
-				  receive();
-			  else
-				  _exitReceiving.Set();
-		  },
-		  ex =>
-		  {
-			  _logger.Fatal(ex.ToString());
-			  error("An exception has occured.");
-			  if (ex.GetType() == typeof(WebSocketException))
-			  {
-				  var wsex = (WebSocketException)ex;
-				  close(wsex.Code, wsex.Message, false);
-			  }
-			  else
-				  close(CloseStatusCode.ABNORMAL, null, false);
-		  });
+      Action receive = null;
+      receive = () => _stream.ReadFrameAsync(
+        frame =>
+        {
+          if (processFrame(frame))
+            receive();
+          else
+            _exitReceiving.Set();
+        },
+        ex =>
+        {
+          _logger.Fatal(ex.ToString());
+          error("An exception has occured.");
+          if (ex.GetType() == typeof(WebSocketException))
+          {
+            var wsex = (WebSocketException)ex;
+            close(wsex.Code, wsex.Message, false);
+          }
+          else
+            close(CloseStatusCode.ABNORMAL, null, false);
+        });
 
-		receive();
-	}
+      receive();
+    }
 
     // As server
     private bool validateConnectionRequest (WebSocketContext context)

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -833,7 +833,7 @@ namespace WebSocketSharp
     {
       _readyState = WebSocketState.OPEN;
 
-      OnOpen.Emit(this, EventArgs.Empty);
+      OnOpen.Emit (this, EventArgs.Empty);
       startReceiving ();
     }
 
@@ -1236,34 +1236,34 @@ namespace WebSocketSharp
       _stream = WsStream.CreateClientStream (_tcpClient, _secure, host, _certValidationCallback);
     }
 
-    private void startReceiving()
+    private void startReceiving ()
     {
-      _exitReceiving = new AutoResetEvent(false);
-      _receivePong = new AutoResetEvent(false);
+      _exitReceiving = new AutoResetEvent (false);
+      _receivePong = new AutoResetEvent (false);
 
       Action receive = null;
-      receive = () => _stream.ReadFrameAsync(
+      receive = () => _stream.ReadFrameAsync (
         frame =>
         {
           if (processFrame(frame))
             receive();
           else
-            _exitReceiving.Set();
+            _exitReceiving.Set ();
         },
         ex =>
         {
-          _logger.Fatal(ex.ToString());
-          error("An exception has occured.");
-          if (ex.GetType() == typeof(WebSocketException))
+          _logger.Fatal (ex.ToString ());
+          error ("An exception has occured.");
+          if (ex.GetType () == typeof (WebSocketException))
           {
-            var wsex = (WebSocketException)ex;
-            close(wsex.Code, wsex.Message, false);
+            var wsex = (WebSocketException) ex;
+            close (wsex.Code, wsex.Message, false);
           }
           else
-            close(CloseStatusCode.ABNORMAL, null, false);
+            close (CloseStatusCode.ABNORMAL, null, false);
         });
 
-      receive();
+      receive ();
     }
 
     // As server

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -245,7 +245,6 @@ namespace WebSocketSharp
 
     #region Public Properties
 
-	// TODO: Submit pull request
 	public IEnumerable<KeyValuePair<string,string>> CustomHeaders { get; set; }
 
     /// <summary>

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -1245,8 +1245,8 @@ namespace WebSocketSharp
       receive = () => _stream.ReadFrameAsync (
         frame =>
         {
-          if (processFrame(frame))
-            receive();
+          if (processFrame (frame))
+            receive ();
           else
             _exitReceiving.Set ();
         },


### PR DESCRIPTION
First off, thanks so much for this library! I was previously using WebSocket4Net which apparently doesn't handle large messages correctly. 

This change adds a `CustomHeaders` property to `WebSocketClient` which will send additional HTTP headers on the handshake request. This isn't exactly per the WebSocket spec, but it was needed for a particular project and it could be useful for others as well.
