### PR TITLE
Change EventArgs constructors acess level

### DIFF
--- a/websocket-sharp/CloseEventArgs.cs
+++ b/websocket-sharp/CloseEventArgs.cs
@@ -58,7 +58,7 @@ namespace WebSocketSharp
 
     #region Internal Constructors
 
-    internal CloseEventArgs ()
+    protected internal CloseEventArgs ()
     {
       _payloadData = new PayloadData ();
       _rawData = _payloadData.ApplicationData;
@@ -67,14 +67,14 @@ namespace WebSocketSharp
       _reason = String.Empty;
     }
 
-    internal CloseEventArgs (ushort code)
+    protected internal CloseEventArgs (ushort code)
     {
       _code = code;
       _reason = String.Empty;
       _rawData = code.InternalToByteArray (ByteOrder.Big);
     }
 
-    internal CloseEventArgs (CloseStatusCode code)
+    protected internal CloseEventArgs (CloseStatusCode code)
       : this ((ushort) code)
     {
     }
@@ -94,14 +94,14 @@ namespace WebSocketSharp
                 : String.Empty;
     }
 
-    internal CloseEventArgs (ushort code, string reason)
+    protected internal CloseEventArgs (ushort code, string reason)
     {
       _code = code;
       _reason = reason ?? String.Empty;
       _rawData = code.Append (reason);
     }
 
-    internal CloseEventArgs (CloseStatusCode code, string reason)
+    protected internal CloseEventArgs (CloseStatusCode code, string reason)
       : this ((ushort) code, reason)
     {
     }

--- a/websocket-sharp/ErrorEventArgs.cs
+++ b/websocket-sharp/ErrorEventArgs.cs
@@ -65,12 +65,12 @@ namespace WebSocketSharp
 
     #region Internal Constructors
 
-    internal ErrorEventArgs (string message)
+    protected internal ErrorEventArgs (string message)
       : this (message, null)
     {
     }
 
-    internal ErrorEventArgs (string message, Exception exception)
+    protected internal ErrorEventArgs (string message, Exception exception)
     {
       _message = message;
       _exception = exception;

--- a/websocket-sharp/MessageEventArgs.cs
+++ b/websocket-sharp/MessageEventArgs.cs
@@ -63,7 +63,7 @@ namespace WebSocketSharp
       _data = convertToString (_opcode, _rawData);
     }
 
-    internal MessageEventArgs (Opcode opcode, byte[] rawData)
+    protected internal MessageEventArgs (Opcode opcode, byte[] rawData)
     {
       if ((ulong) rawData.LongLength > PayloadData.MaxLength)
         throw new WebSocketException (CloseStatusCode.TooBig);


### PR DESCRIPTION
Make some of the constructors of the various EventArg classes
internal protected instead of internal so they can be created by
derived classes for easier test creation
