### PR TITLE
send callback whenever a server ping is recieved for websocket client

### DIFF
--- a/websocket-sharp/Server/WebSocketBehavior.cs
+++ b/websocket-sharp/Server/WebSocketBehavior.cs
@@ -286,6 +286,10 @@ namespace WebSocketSharp.Server
       OnMessage (e);
     }
 
+    private void onPingMessageRecieved (object sender, EventArgs e) 
+    {
+        OnPingMessageRecieved();
+    }
     private void onOpen (object sender, EventArgs e)
     {
       _id = _sessions.Add (this);
@@ -326,7 +330,7 @@ namespace WebSocketSharp.Server
       _websocket.OnMessage += onMessage;
       _websocket.OnError += onError;
       _websocket.OnClose += onClose;
-
+      _websocket.OnPingRecieved += onPingMessageRecieved; 
       _websocket.ConnectAsServer ();
     }
 
@@ -386,6 +390,17 @@ namespace WebSocketSharp.Server
     protected virtual void OnMessage (MessageEventArgs e)
     {
     }
+
+        /// <summary>
+        /// Called when the <see cref="WebSocket"/> used in the current session receives a message.
+        /// </summary>
+        /// <param name="e">
+        /// A <see cref="MessageEventArgs"/> that represents the event data passed to
+        /// a <see cref="WebSocket.OnMessage"/> event.
+        /// </param>
+        protected virtual void OnPingMessageRecieved ()
+        {
+        }
 
     /// <summary>
     /// Called when the WebSocket connection used in the current session has been established.

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -554,6 +554,11 @@ namespace WebSocketSharp
     /// </summary>
     public event EventHandler OnOpen;
 
+
+     /// <summary>
+     /// Occurs when the <see cref="WebSocket"/> receives a message.
+    /// </summary>
+    public event EventHandler OnPingRecieved;
     #endregion
 
     #region Private Methods
@@ -1023,7 +1028,7 @@ namespace WebSocketSharp
     {
       if (send (new WebSocketFrame (Opcode.Pong, frame.PayloadData, _client).ToByteArray ()))
         _logger.Trace ("Returned a Pong.");
-
+      OnPingRecieved.Emit (this, EventArgs.Empty);
       return true;
     }
 


### PR DESCRIPTION
A callback in case of pings not being received would help the client check whether connectivity is lost without sending a ping from the client periodically.