### PR TITLE
Make HttpServer more consistent with WebSocketServer

### DIFF
--- a/websocket-sharp/Ext.cs
+++ b/websocket-sharp/Ext.cs
@@ -924,6 +924,70 @@ namespace WebSocketSharp
       return true;
     }
 
+    /// <summary>
+    /// Tries to create a <see cref="Uri"/> for HTTP with the specified
+    /// <paramref name="uriString"/>.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if a <see cref="Uri"/> is successfully created; otherwise, <c>false</c>.
+    /// </returns>
+    /// <param name="uriString">
+    /// A <see cref="string"/> that represents the HTTP URL to try.
+    /// </param>
+    /// <param name="result">
+    /// When this method returns, a <see cref="Uri"/> that represents the HTTP URL
+    /// if <paramref name="uriString"/> is valid; otherwise, <see langword="null"/>.
+    /// </param>
+    /// <param name="message">
+    /// When this method returns, a <see cref="string"/> that represents the error message
+    /// if <paramref name="uriString"/> is invalid; otherwise, <see cref="String.Empty"/>.
+    /// </param>
+    internal static bool TryCreateHttpUri (
+      this string uriString, out Uri result, out string message)
+    {
+      result = null;
+
+      var uri = uriString.ToUri ();
+      if (!uri.IsAbsoluteUri) {
+        message = "Not an absolute URI: " + uriString;
+        return false;
+      }
+
+      var schm = uri.Scheme;
+      if (schm != "http" && schm != "https") {
+        message = "The scheme part isn't 'http' or 'https': " + uriString;
+        return false;
+      }
+
+      if (uri.Fragment.Length > 0) {
+        message = "Includes the fragment component: " + uriString;
+        return false;
+      }
+
+      var port = uri.Port;
+      if (port > 0) {
+        if (port > 65535) {
+          message = "The port part is greater than 65535: " + uriString;
+          return false;
+        }
+
+        if ((schm == "http" && port == 443) || (schm == "https" && port == 80)) {
+          message = "An invalid pair of scheme and port: " + uriString;
+          return false;
+        }
+      }
+      else {
+        uri = new Uri (
+          String.Format (
+            "{0}://{1}:{2}{3}", schm, uri.Host, schm == "http" ? 80 : 443, uri.PathAndQuery));
+      }
+
+      result = uri;
+      message = String.Empty;
+
+      return true;
+    }
+
     internal static string Unquote (this string value)
     {
       var start = value.IndexOf ('"');

--- a/websocket-sharp/Net/HttpConnection.cs
+++ b/websocket-sharp/Net/HttpConnection.cs
@@ -286,14 +286,12 @@ namespace WebSocketSharp.Net
 
           if (conn._context.HasError) {
             conn.SendError ();
-            conn.Close (true);
 
             return;
           }
 
           if (!conn._listener.BindContext (conn._context)) {
             conn.SendError ("Invalid host", 400);
-            conn.Close (true);
 
             return;
           }
@@ -537,6 +535,7 @@ namespace WebSocketSharp.Net
           var res = _context.Response;
           res.StatusCode = status;
           res.ContentType = "text/html";
+          res.ContentEncoding = Encoding.UTF8;
 
           var desc = status.GetStatusDescription ();
           var msg = message != null && message.Length > 0

--- a/websocket-sharp/Server/WebSocketServer.cs
+++ b/websocket-sharp/Server/WebSocketServer.cs
@@ -257,6 +257,9 @@ namespace WebSocketSharp.Server
     /// </exception>
     public WebSocketServer (System.Net.IPAddress address, int port, bool secure)
     {
+      if (address == null)
+        throw new ArgumentNullException ("address");
+
       if (!address.IsLocal ())
         throw new ArgumentException ("Not a local IP address: " + address, "address");
 


### PR DESCRIPTION
This makes `HttpServer` more consistent with `WebSocketServer` by adding missing constructor overloads and properties.

* Adds constructor overloads enabling listening on specific IP addresses
* Adds a constructor to get listen parameters from a URL string
* Fixes a missing null check for `IPAddress` parameters in `WebSocketServer`
* Fixes an error that prevented `HttpServer` from sending error messages (`HttpConnection.cs`)
