### PR TITLE
Allow port 443 on ws:// protocol and allow port 80 on wss://

### DIFF
--- a/websocket-sharp/Ext.cs
+++ b/websocket-sharp/Ext.cs
@@ -877,10 +877,6 @@ namespace WebSocketSharp
           return false;
         }
 
-        if ((schm == "ws" && port == 443) || (schm == "wss" && port == 80)) {
-          message = "An invalid pair of scheme and port: " + uriString;
-          return false;
-        }
       }
       else {
         uri = new Uri (


### PR DESCRIPTION
Closes #127

As described in the issue above, the port/protocol scheme isn't always as rigid as the current code assumes. A lot of times ws:// protocol is used on port 443, and if the developer explicitly specifies which protocol and which port the library should, at the very least, try to connect. Making sure appropriate protocol and port are used should be handled on a project basis, and the library should just try to connect to whatever is given to it.