### PR TITLE
Provide client certificate in WebSocketContext #164

### DIFF
--- a/websocket-sharp/Net/WebSockets/HttpListenerWebSocketContext.cs
+++ b/websocket-sharp/Net/WebSockets/HttpListenerWebSocketContext.cs
@@ -30,6 +30,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 
 namespace WebSocketSharp.Net.WebSockets
@@ -144,6 +146,18 @@ namespace WebSocketSharp.Net.WebSockets
     public override bool IsSecureConnection {
       get {
         return _context.Connection.IsSecure;
+      }
+    }
+
+    /// <summary>
+    /// Gets client certificate provided during connection or null if certificate is not used.
+    /// </summary>
+    /// <value>
+    /// A <see cref="X509Certificate"/> representing used client certificate or null if certificate is not present.
+    /// </value>
+    public override X509Certificate ClientCertificate {
+      get {
+        return _context.Request.GetClientCertificate();
       }
     }
 

--- a/websocket-sharp/Net/WebSockets/TcpListenerWebSocketContext.cs
+++ b/websocket-sharp/Net/WebSockets/TcpListenerWebSocketContext.cs
@@ -202,6 +202,25 @@ namespace WebSocketSharp.Net.WebSockets
     }
 
     /// <summary>
+    /// Gets client certificate provided during connection or null if certificate is not used.
+    /// </summary>
+    /// <value>
+    /// A <see cref="X509Certificate"/> representing used client certificate or null if certificate is not present.
+    /// </value>
+    public override X509Certificate ClientCertificate {
+      get {
+        if (_stream == null)
+          return null;
+
+        SslStream sslStream = _stream as SslStream;
+        if (sslStream == null)
+          return null;
+
+        return sslStream.RemoteCertificate;
+      }
+    }
+
+    /// <summary>
     /// Gets a value indicating whether the request is a WebSocket connection request.
     /// </summary>
     /// <value>
@@ -350,7 +369,6 @@ namespace WebSocketSharp.Net.WebSockets
         return _websocket;
       }
     }
-
     #endregion
 
     #region Internal Methods

--- a/websocket-sharp/Net/WebSockets/WebSocketContext.cs
+++ b/websocket-sharp/Net/WebSockets/WebSocketContext.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 
 namespace WebSocketSharp.Net.WebSockets
@@ -101,6 +102,14 @@ namespace WebSocketSharp.Net.WebSockets
     /// <c>true</c> if the connection is secured; otherwise, <c>false</c>.
     /// </value>
     public abstract bool IsSecureConnection { get; }
+
+    /// <summary>
+    /// Gets client certificate provided during connection or null if certificate is not used.
+    /// </summary>
+    /// <value>
+    /// A <see cref="X509Certificate"/> representing used client certificate or null if certificate is not present.
+    /// </value>
+    public abstract X509Certificate ClientCertificate { get; }
 
     /// <summary>
     /// Gets a value indicating whether the request is a WebSocket connection request.


### PR DESCRIPTION
Attempt to solve issue #164

Attempt to expose client certificate in WebSocketContext. Works so far only for TcpListenerWebSocketContext. HttlListenerRequest used in HttpListenerWebSocketcontext does not have methods for client certificate implemented yet.
