### PR TITLE
Add intergration seam to Logger

### DIFF
--- a/websocket-sharp/Logger.cs
+++ b/websocket-sharp/Logger.cs
@@ -32,6 +32,16 @@ using System.IO;
 
 namespace WebSocketSharp
 {
+  public interface IWebSocketLogger
+  {
+      void Debug (string message);
+      void Error (string message);
+      void Fatal (string message);
+      void Info (string message);
+      void Trace (string message);
+      void Warn (string message);
+  }
+
   /// <summary>
   /// Provides a set of methods and properties for logging.
   /// </summary>
@@ -49,7 +59,7 @@ namespace WebSocketSharp
   ///   <see cref="Logger.Output"/> to any <c>Action&lt;LogData, string&gt;</c> delegate.
   ///   </para>
   /// </remarks>
-  public class Logger
+  public class Logger : IWebSocketLogger
   {
     #region Private Fields
 

--- a/websocket-sharp/Server/WebSocketBehavior.cs
+++ b/websocket-sharp/Server/WebSocketBehavior.cs
@@ -78,7 +78,7 @@ namespace WebSocketSharp.Server
     /// A <see cref="Logger"/> that provides the logging functions,
     /// or <see langword="null"/> if the WebSocket connection isn't established.
     /// </value>
-    protected Logger Log {
+    protected IWebSocketLogger Log {
       get {
         return _websocket != null ? _websocket.Log : null;
       }

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -91,7 +91,7 @@ namespace WebSocketSharp
                                     _handshakeRequestChecker;
     private bool                    _ignoreExtensions;
     private bool                    _inContinuation;
-    private volatile Logger         _logger;
+    private volatile IWebSocketLogger _logger;
     private Queue<MessageEventArgs> _messageEventQueue;
     private uint                    _nonceCount;
     private string                  _origin;
@@ -435,12 +435,12 @@ namespace WebSocketSharp
     /// <value>
     /// A <see cref="Logger"/> that provides the logging functions.
     /// </value>
-    public Logger Log {
+    public IWebSocketLogger Log {
       get {
         return _logger;
       }
 
-      internal set {
+      set {
         _logger = value;
       }
     }


### PR DESCRIPTION
In our usage of websocket-sharp we need to integrate our logging infrastructure with websocket-sharp's. This PR adds a seam which allows the Logger implementation to be swapped out. Existing users are not affected. 

Downstream users wishing to use their own logger would simply use the `Log` setter:

```cs
var webSocket = new WebSocket("ws://websocket.org/echo")
{
  Log = new Log4NetWebSocketLogger()
};
```

### Example integration

Below is an integration example for plain Log4Net.

```cs
public class Log4NetWebSocketLogger : IWebSocketLogger
{
    private readonly ILog _log;

    public Log4NetWebSocketLogger()
    {
        _log = LogManager.GetLogger(typeof(WebSocket));
    }

    public void Debug(string message)
    {
        _log.Debug(message);
    }

    public void Error(string message)
    {
        _log.Error(message);
    }

    public void Fatal(string message)
    {
        _log.Fatal(message);
    }

    public void Info(string message)
    {
        _log.Info(message);
    }

    public void Trace(string message)
    {
        _log.Debug(message);
    }

    public void Warn(string message)
    {
        _log.Warn(message);
    }
}
```

Thank you for your consideration. Let me know if there is anything I can do to improve this PR.