### PR TITLE
fixes ExecutionEngineException subscribing to events on iOS by adding a Property

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -603,22 +603,54 @@ namespace WebSocketSharp
     /// <summary>
     /// Occurs when the WebSocket connection has been closed.
     /// </summary>
-    public event EventHandler<CloseEventArgs> OnClose;
+    event EventHandler<CloseEventArgs> onClose;
+    public event EventHandler<CloseEventArgs> OnClose {
+		add {
+			onClose = (EventHandler<CloseEventArgs>)Delegate.Combine(onClose, value);
+		}
+		remove {
+			onClose = (EventHandler<CloseEventArgs>)Delegate.Remove(onClose, value);
+		}
+	}
 
     /// <summary>
     /// Occurs when the <see cref="WebSocket"/> gets an error.
     /// </summary>
-    public event EventHandler<ErrorEventArgs> OnError;
+    event EventHandler<ErrorEventArgs> onError;
+    public event EventHandler<ErrorEventArgs> OnError {
+		add {
+			onError = (EventHandler<ErrorEventArgs>)Delegate.Combine(onError, value);
+		}
+		remove {
+			onError = (EventHandler<ErrorEventArgs>)Delegate.Remove(onError, value);
+		}
+	}
 
     /// <summary>
     /// Occurs when the <see cref="WebSocket"/> receives a message.
     /// </summary>
-    public event EventHandler<MessageEventArgs> OnMessage;
+    event EventHandler<MessageEventArgs> onMessage;
+    public event EventHandler<MessageEventArgs> OnMessage {
+		add {
+			onMessage = (EventHandler<MessageEventArgs>)Delegate.Combine(onMessage, value);
+		}
+		remove {
+			onMessage = (EventHandler<MessageEventArgs>)Delegate.Remove(onMessage, value);
+		}
+	}
 
     /// <summary>
     /// Occurs when the WebSocket connection has been established.
     /// </summary>
-    public event EventHandler OnOpen;
+    event EventHandler onOpen;
+    public event EventHandler OnOpen {
+		add {
+			onOpen = (EventHandler)Delegate.Combine(onOpen, value);
+		}
+		remove {
+			onOpen = (EventHandler)Delegate.Remove(onOpen, value);
+		}
+	}
 
     #endregion
 
@@ -767,7 +799,7 @@ namespace WebSocketSharp
 
       _readyState = WebSocketState.Closed;
       try {
-        OnClose.Emit (this, e);
+        onClose.Emit (this, e);
       }
       catch (Exception ex) {
         _logger.Fatal (ex.ToString ());
@@ -947,7 +979,7 @@ namespace WebSocketSharp
     private void error (string message, Exception exception)
     {
       try {
-        OnError.Emit (this, new ErrorEventArgs (message, exception));
+        onError.Emit (this, new ErrorEventArgs (message, exception));
       }
       catch (Exception ex) {
         _logger.Fatal (ex.ToString ());
@@ -973,7 +1005,7 @@ namespace WebSocketSharp
 
         lock (_forEvent) {
           try {
-            OnOpen.Emit (this, EventArgs.Empty);
+            onOpen.Emit (this, EventArgs.Empty);
           }
           catch (Exception ex) {
             processException (ex, "An exception has occurred during an OnOpen event.");
@@ -1508,7 +1540,7 @@ namespace WebSocketSharp
               try {
                 var e = dequeueFromMessageEventQueue ();
                 if (e != null && _readyState == WebSocketState.Open)
-                  OnMessage.Emit (this, e);
+                  onMessage.Emit (this, e);
               }
               catch (Exception ex) {
                 processException (ex, "An exception has occurred during an OnMessage event.");
@@ -1711,7 +1743,7 @@ namespace WebSocketSharp
 
       _readyState = WebSocketState.Closed;
       try {
-        OnClose.Emit (this, e);
+        onClose.Emit (this, e);
       }
       catch (Exception ex) {
         _logger.Fatal (ex.ToString ());


### PR DESCRIPTION
I'm using websocket-sharp in Unity 5.2.2f1 building an app for iOS 9.0.2.

I was getting the error:

    ExecutionEngineException: Attempting to JIT compile method '(wrapper managed-to-native)System.Threading.Interlocked.CompareExchange...

And found this thread:

http://forum.unity3d.com/threads/executionengineexception-on-ios-only.113750/

Which describes fixing the issue by adding a Property for your public delegates that handles the increment/decrement operators. This change seems to fix the problem for me.