### PR TITLE
Make it handle ipv6

### DIFF
--- a/websocket-sharp/Net/HttpListenerPrefix.cs
+++ b/websocket-sharp/Net/HttpListenerPrefix.cs
@@ -120,26 +120,12 @@ namespace WebSocketSharp.Net
 
     private void parse (string uriPrefix)
     {
-      var defaultPort = uriPrefix.StartsWith ("https://") ? 443 : 80;
-      if (defaultPort == 443)
-        _secure = true;
+      var uri = new System.Uri(uriPrefix);
 
-      var len = uriPrefix.Length;
-      var startHost = uriPrefix.IndexOf (':') + 3;
-      var colon = uriPrefix.IndexOf (':', startHost, len - startHost);
-      var root = 0;
-      if (colon > 0) {
-        root = uriPrefix.IndexOf ('/', colon, len - colon);
-        _host = uriPrefix.Substring (startHost, colon - startHost);
-        _port = (ushort) Int32.Parse (uriPrefix.Substring (colon + 1, root - colon - 1));
-      }
-      else {
-        root = uriPrefix.IndexOf ('/', startHost, len - startHost);
-        _host = uriPrefix.Substring (startHost, root - startHost);
-        _port = (ushort) defaultPort;
-      }
-
-      _path = uriPrefix.Substring (root);
+      _port = (ushort)uri.Port;
+      _host = uri.Host;
+      _path = uri.PathAndQuery;
+      _secure = uri.Scheme.Equals("https");
 
       var pathLen = _path.Length;
       if (pathLen > 1)
@@ -152,42 +138,13 @@ namespace WebSocketSharp.Net
 
     public static void CheckPrefix (string uriPrefix)
     {
-      if (uriPrefix == null)
-        throw new ArgumentNullException ("uriPrefix");
+        var uri = new System.Uri(uriPrefix);
 
-      var len = uriPrefix.Length;
-      if (len == 0)
-        throw new ArgumentException ("An empty string.");
+        if (!uri.Scheme.Equals("http") && !uri.Scheme.Equals("https"))
+          throw new ArgumentException ("The scheme isn't 'http' or 'https'.");
 
-      if (!(uriPrefix.StartsWith ("http://") || uriPrefix.StartsWith ("https://")))
-        throw new ArgumentException ("The scheme isn't 'http' or 'https'.");
-
-      var startHost = uriPrefix.IndexOf (':') + 3;
-      if (startHost >= len)
-        throw new ArgumentException ("No host is specified.");
-
-      var colon = uriPrefix.IndexOf (':', startHost, len - startHost);
-      if (startHost == colon)
-        throw new ArgumentException ("No host is specified.");
-
-      if (colon > 0) {
-        var root = uriPrefix.IndexOf ('/', colon, len - colon);
-        if (root == -1)
-          throw new ArgumentException ("No path is specified.");
-
-        int port;
-        if (!Int32.TryParse (uriPrefix.Substring (colon + 1, root - colon - 1), out port) ||
-            !port.IsPortNumber ())
-          throw new ArgumentException ("An invalid port is specified.");
-      }
-      else {
-        var root = uriPrefix.IndexOf ('/', startHost, len - startHost);
-        if (root == -1)
-          throw new ArgumentException ("No path is specified.");
-      }
-
-      if (uriPrefix[len - 1] != '/')
-        throw new ArgumentException ("Ends without '/'.");
+        if (!uri.PathAndQuery.EndsWith("/"))
+          throw new ArgumentException ("Ends without '/'.");
     }
 
     // The Equals and GetHashCode methods are required to detect duplicates in any collection.

--- a/websocket-sharp/websocket-sharp.csproj
+++ b/websocket-sharp/websocket-sharp.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>websocket-sharp.snk</AssemblyOriginatorKeyFile>
+    <UseMSBuildEngine>False</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -48,12 +49,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <GenerateDocumentation>true</GenerateDocumentation>
     <CustomCommands>
       <CustomCommands>
-        <Command type="AfterBuild" command="doc/doc.sh" workingdir="doc/" externalConsole="true" />
+        <Command type="AfterBuild" command="doc/doc.sh" workingdir="doc/" externalConsole="True" />
       </CustomCommands>
     </CustomCommands>
+    <DocumentationFile>bin\Release_Ubuntu\websocket-sharp.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
So I think this does what you want? See issue #262 

`HttpListenerPrefix.parse` and `HttpListener.CheckPrefix` seemed to be parsing incorrectly checking for colon to find the port which is problematic with ipv6 addresses.

Also `HttpServer(url)` was passing the host to `System.Net.Dns.GetHostAddresses` but that failed if the host was already an ip address

With this change I can do both of these

    HttpServer server = new HttpServer(System.Net.IPAddress.Parse("::0"), 8080);
    HttpServer server = new HttpServer("http://[::0]:8080");

As for the PR itself `Uri.PathAndQuery` will be at least `/` always (tested) so no need to check for it being empty. It is possible it doesn't end with `/` though so I left that check.

Note that with this change this `HttpServer server = new HttpServer("http://[::0]:8080");` path started working on ipv6 for me. The first path doesn't yet for some reason