### PR TITLE
AWS ELB 2.0 support on IIS environment.

### DIFF
--- a/AWS Compatibility/IIS Environment/.ebextensions/01_pre_deploy.config
+++ b/AWS Compatibility/IIS Environment/.ebextensions/01_pre_deploy.config
@@ -1,0 +1,16 @@
+commands:
+  01_default_website_disable:
+    test: cmd /c "if exist C:\\Users\\Public\\initialized (exit 1) else (exit 0)"
+    command: C:\Windows\System32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/httpLogging /dontLog:"True" /commit:apphost
+    ignoreErrors: true
+  02_install_websockets_feature:
+    test: cmd /c "if exist C:\\Users\\Public\\initialized (exit 1) else (exit 0)"
+    command: C:\Windows\system32\DISM.EXE /enable-feature /online /featureName:"IIS-WebSockets"
+    ignoreErrors: true
+  03_setting_firewall_for_websocket_port:
+    test: cmd /c "if exist C:\\Users\\Public\\initialized (exit 1) else (exit 0)"
+    command: netsh advfirewall firewall add rule name="World Wide Web Socket Port" dir=in action=allow protocol=TCP localport=8000
+    ignoreErrors: true
+  04_initializing:
+    test: cmd /c "if exist C:\\Users\\Public\\initialized (exit 1) else (exit 0)"
+    command: copy NUL C:\\Users\\Public\\initialized

--- a/AWS Compatibility/IIS Environment/.ebextensions/02_environment_settings.config
+++ b/AWS Compatibility/IIS Environment/.ebextensions/02_environment_settings.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:environment:
+    LoadBalancerType: application

--- a/websocket-sharp/Server/WebSocketServer.cs
+++ b/websocket-sharp/Server/WebSocketServer.cs
@@ -618,7 +618,7 @@ namespace WebSocketSharp.Server
     private void processRequest (TcpListenerWebSocketContext context)
     {
       var uri = context.RequestUri;
-      if (uri == null || uri.Port != _port) {
+      if (uri == null) {
         context.Close (HttpStatusCode.BadRequest);
         return;
       }


### PR DESCRIPTION
Hello STA.BLOCKHEAD developer

I used to your websocket-sharp library for making realtime service (the project running with IIS 8.5 and .NET).

This library working perfectly on local environment of my computer.

But the problem occurred when i deployed the project to cloud server (like AWS Beanstalk).

The cloud environment is running belong to Load Balancer (ELB 2.0 : Elastic Load Balancer).

The load balancer has some problem when running other portocol that unlike SOAP(http, https), like ws(websocket protocol), Yes you can solve this problem to use ALB (or ELB 2.0) in AWS.

But ALB (or ELB 2.0) change origin websocket request url to new url that be fixed 80 port. 

Connection will be has problem to IF clause at 621 line of your source file Server/WebSocketServer.cs, so you need to remove `_port` condition.

And also i attached the script files for setting Elastic Beanstalk service in IIS environment.

Thank you for reading.