### PR TITLE
Allow user to read Ping data.

### DIFF
--- a/websocket-sharp/PayloadData.cs
+++ b/websocket-sharp/PayloadData.cs
@@ -115,6 +115,21 @@ namespace WebSocketSharp
       _codeSet = true;
       _reasonSet = true;
     }
+    
+    internal PayloadData(PayloadData original)
+    {        
+        _code = original._code;
+        _codeSet = original._codeSet;            
+        _extDataLength = original._extDataLength;
+        _length = original._length;
+        _reason = original._reason;
+        _reasonSet = original._reasonSet;
+
+        _data = new byte[_length];
+        original._data.CopyTo(_data, 0);
+
+        
+    }
 
     #endregion
 

--- a/websocket-sharp/WebSocketFrame.cs
+++ b/websocket-sharp/WebSocketFrame.cs
@@ -108,8 +108,9 @@ namespace WebSocketSharp
       _rsv2 = Rsv.Off;
       _rsv3 = Rsv.Off;
       _opcode = opcode;
+      _payloadData = new PayloadData(payloadData);
 
-      var len = payloadData.Length;
+      var len = _payloadData.Length;
       if (len < 126) {
         _payloadLength = (byte) len;
         _extPayloadLength = WebSocket.EmptyBytes;
@@ -126,14 +127,13 @@ namespace WebSocketSharp
       if (mask) {
         _mask = Mask.On;
         _maskingKey = createMaskingKey ();
-        payloadData.Mask (_maskingKey);
+        _payloadData.Mask (_maskingKey);
       }
       else {
         _mask = Mask.Off;
         _maskingKey = WebSocket.EmptyBytes;
       }
 
-      _payloadData = payloadData;
     }
 
     #endregion


### PR DESCRIPTION
Fixed WebSocketFrame constructor so it does not modify the PayloadData passed by parameter, allowing the user to access the data in a ping packet. Previously the WebSocketFrame constructor masked the data, so when the event reached the user the data was unreadable. 

A new PayloadData copy constructor was necessary for that purpose.