### PR TITLE
adopt to compare string terminology.

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -776,23 +776,28 @@ namespace WebSocketSharp
         return false;
       }
 
-      var headers = response.Headers;
-      if (!validateSecWebSocketAcceptHeader (headers["Sec-WebSocket-Accept"])) {
+      var headersSource = response.Headers;
+      var headers = new NameValueCollection();
+      foreach (var name in headersSource.AllKeys) {
+                headers[name.ToLower()] = headersSource[name];
+      }
+
+      if (!validateSecWebSocketAcceptHeader (headers[("Sec-WebSocket-Accept").ToLower()])) {
         message = "Includes no Sec-WebSocket-Accept header, or it has an invalid value.";
         return false;
       }
 
-      if (!validateSecWebSocketProtocolServerHeader (headers["Sec-WebSocket-Protocol"])) {
+      if (!validateSecWebSocketProtocolServerHeader (headers[("Sec-WebSocket-Protocol").ToLower()])) {
         message = "Includes no Sec-WebSocket-Protocol header, or it has an invalid value.";
         return false;
       }
 
-      if (!validateSecWebSocketExtensionsServerHeader (headers["Sec-WebSocket-Extensions"])) {
+      if (!validateSecWebSocketExtensionsServerHeader (headers[("Sec-WebSocket-Extensions").ToLower()])) {
         message = "Includes an invalid Sec-WebSocket-Extensions header.";
         return false;
       }
 
-      if (!validateSecWebSocketVersionServerHeader (headers["Sec-WebSocket-Version"])) {
+      if (!validateSecWebSocketVersionServerHeader (headers[("Sec-WebSocket-Version").ToLower()])) {
         message = "Includes an invalid Sec-WebSocket-Version header.";
         return false;
       }
@@ -1185,10 +1190,10 @@ namespace WebSocketSharp
         throw new WebSocketException (CloseStatusCode.ProtocolError, msg);
 
       if (_protocolsRequested)
-        _protocol = res.Headers["Sec-WebSocket-Protocol"];
+        _protocol = res.Headers[("Sec-WebSocket-Protocol").ToLower()];
 
       if (_extensionsRequested)
-        processSecWebSocketExtensionsServerHeader (res.Headers["Sec-WebSocket-Extensions"]);
+        processSecWebSocketExtensionsServerHeader (res.Headers[("Sec-WebSocket-Extensions").ToLower()]);
 
       processCookies (res.Cookies);
     }


### PR DESCRIPTION
some server returns handshake headers with case-insensitive rule.

according to HTTP1.1(https://tools.ietf.org/html/rfc2616#section-2.1),
,

"literal"
Quotation marks surround literal text. Unless stated otherwise,
the text is case-insensitive.

also in RFC of WS(https://tools.ietf.org/html/rfc6455#section-4.1),

Comparing two strings in an _ASCII case-insensitive_ manner means
comparing them exactly, code point for code point, except that the
characters in the range U+0041 to U+005A (i.e., LATIN CAPITAL LETTER
A to LATIN CAPITAL LETTER Z) and the corresponding characters in the
range U+0061 to U+007A (i.e., LATIN SMALL LETTER A to LATIN SMALL
LETTER Z) are considered to also match.