### PR TITLE
#394: added WebSocket.SendTimout to fix issue: https://github.com/sta…

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -624,6 +624,52 @@ namespace WebSocketSharp
       }
     }
 
+    /// <summary>
+    /// Gets or sets the send timeout.
+    /// </summary>
+    /// <value>
+    /// A <see cref="TimeSpan"/> that represents the send timeout. The default value is the same as
+    /// underlying stream WriteTimeout.
+    /// </value>
+    public TimeSpan SendTimeout {
+      get {
+        if (_stream.WriteTimeout <= 0)
+        {
+          return TimeSpan.Zero;
+        }
+        return TimeSpan.FromMilliseconds(_stream.WriteTimeout);
+      }
+
+      set {
+        lock (_forSend) {
+          string msg;
+          if (!checkIfAvailable (true, true, false, true, false, false, out msg)) {
+            _logger.Error (msg);
+            error ("An error has occurred in setting the send timeout.", null);
+
+            return;
+          }
+
+          try
+          {
+            if (value <= TimeSpan.Zero)
+            {
+              _stream.WriteTimeout = -1;
+            }
+            else
+            {
+              _stream.WriteTimeout = (int)value.TotalMilliseconds;
+            }
+          }
+          catch(Exception ex)
+          {
+            _logger.Error (ex.ToString());
+            error ("An error has occurred in setting the send timeout.", ex);
+          }
+        }
+      }
+    }
+
     #endregion
 
     #region Public Events


### PR DESCRIPTION
…/websocket-sharp/issues/394

**Problem description:**
One of our web socket clients for some reason stopped receiving messages(Some bug in our client code). This stopped message delivery to all other clients. After investigating this issue we saw that WebSocketServiceManager.Broadcast() got stuck on delivery to that buggy client for 5+ hours.

**Steps to reproduce:**
1. Start WebSocketServer
2. Connect to WebSocket from client(without Receive)
3. Start loop with WebSocketServiceManager.Broadcast(/1KB/) with 10000 iterations
4. Actual result:
5. WebSocketServiceManager.Broadcast() got stuck on 172th iteration

**Expected result:**
Loop should complete successfully

**Proposed solution:**
Add property WebSocket.SendTimeout to limit sending message into socket.