### PR TITLE
fix a bug at  QueryString

### DIFF
--- a/websocket-sharp/Net/HttpListenerRequest.cs
+++ b/websocket-sharp/Net/HttpListenerRequest.cs
@@ -343,8 +343,10 @@ namespace WebSocketSharp.Net
     /// </value>
     public NameValueCollection QueryString {
       get {
+        //fix bug, if ContentEncoding is GB2312 ,UrlDecode will return ??? 
+        //TODO,how to get paratermers when method is POST
         return _queryString ??
-               (_queryString = HttpUtility.InternalParseQueryString (_url.Query, Encoding.UTF8));
+               (_queryString = HttpUtility.InternalParseQueryString (_url.Query,this.ContentEncoding));
       }
     }
 


### PR DESCRIPTION
if ContentEncoding is not UTF-8,and the value is a unicode char 
InternalParseQueryString (_url.Query) will return value "???" instead of the true value
use ContentEncoding can fixed it