### PR TITLE
Internal method/property cannot be accessed when compiled into DLL

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -320,7 +320,7 @@ namespace WebSocketSharp
       }
     }
 
-    internal bool IsConnected {
+    public bool IsConnected {
       get {
         return _readyState == WebSocketState.Open || _readyState == WebSocketState.Closing;
       }


### PR DESCRIPTION
I need to check IsConnected property. But once I compiled this library into a DLL, I cannot access the property from another script because the accessibility was set internal.