### PR TITLE
For some use cases, IsConnected method needs to be public.

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -320,12 +320,6 @@ namespace WebSocketSharp
       }
     }
 
-    internal bool IsConnected {
-      get {
-        return _readyState == WebSocketState.Open || _readyState == WebSocketState.Closing;
-      }
-    }
-
     #endregion
 
     #region Public Properties
@@ -768,6 +762,12 @@ namespace WebSocketSharp
         }
       }
     }
+
+	public bool IsConnected {
+		get {
+			return _readyState == WebSocketState.Open || _readyState == WebSocketState.Closing;
+		}
+	}
 
     #endregion
 


### PR DESCRIPTION
Moved IsConnected from Internal Properties to Public Properties. Changed the access modifier from internal to public.