### PR TITLE
Fix for indefinte timeout during connect

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -2133,6 +2133,9 @@ namespace WebSocketSharp
             conf.ServerCertificateValidationCallback,
             conf.ClientCertificateSelectionCallback);
 
+          sslStream.ReadTimeout = (int)WaitTime.TotalMilliseconds;
+          sslStream.WriteTimeout = (int)WaitTime.TotalMilliseconds;
+
           sslStream.AuthenticateAsClient (
             host,
             conf.ClientCertificates,


### PR DESCRIPTION
Problem
Encountered a Situation where during the connection of a secure websocket client the connect method waited indefinitely on SslStream.AuthenticateAsClient, never successfully connecting or raising a close/error event. From analyzing memory dumps of affected clients and related server logs determined that the cause was that a network interruption occurred during the connect causing a half open tcp connection where the server had closed the connection on its end but the client still believed the connection to be open (https://blog.stephencleary.com/2009/05/detection-of-half-open-dropped.html).  The timeout for the SslStream.AuthenticateAsClient is based on the SslStream.ReadTimeout property which has a default of indefinite (https://msdn.microsoft.com/en-us/library/system.net.security.sslstream.readtimeout(v=vs.110).aspx). This situation prevented our reconnection logic from being triggered as it was based on the OnClose and OnError events. 

Proposed Fix
Update the setClientStream method of the WebSocket class to set the sslStream ReadTimeout and WriteTimeout properties to the TotalMiliseconds of the WaitTime property that is used as a timeout for the ping and close methods. This will cause the WebSocket class to raise a close and error event when the WaitTime has been exceeded.

Testing
Was able to reproduce this situation with the following steps.
1. Modified the constructor of the TcpListenerWebSocketContext to wait 60 seconds before calling the sslStream.AuthenticateAsServer method.
2. Deployed the modified websocket server to a remote vm.
3. Initiated a connect from a local client.
4. Removed Ethernet connection of local client.
5. Waited over 60 seconds.
6. Reconnected Ethernet connection of local client.
7. Observed that the server abandoned the connection, while the local client continued to wait for connect without raising OnClose or OnError.

Was able to validate the fix using the following steps.
1. Set the WaitTime of the local client to 5 minutes.
3. Initiated a connect from a local client.
4. Removed Ethernet connection of local client.
5. Waited over 60 seconds.
6. Reconnected Ethernet connection of local client.
7. Observed that the local client raised both the OnError and OnClose events when the 5 minute limit had been reached.
