### PR TITLE
Adding stream timeouts

### DIFF
--- a/websocket-sharp/Net/HttpConnection.cs
+++ b/websocket-sharp/Net/HttpConnection.cs
@@ -221,7 +221,10 @@ namespace WebSocketSharp.Net
       _inputStream = null;
       _outputStream = null;
 
-      _stream.Dispose ();
+      try {
+        _stream.Dispose();
+      }
+      catch { }
       _stream = null;
     }
 

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -119,8 +119,8 @@ namespace WebSocketSharp
     private Uri                            _uri;
     private const string                   _version = "13";
     private TimeSpan                       _waitTime;
-    private int                            _connectTimeout;
-    private int                            _readWriteTimeout;
+    private int                            _connectTimeout = 5000;
+    private int                            _readWriteTimeout = 5000;
 
     #endregion
 
@@ -1911,8 +1911,8 @@ namespace WebSocketSharp
           error ("An error has occurred during a send.", ex);
         }
         finally {
-          if (compressed) { 
-            try { 
+          if (compressed) {
+            try {
               stream.Dispose ();
             }
             catch { }


### PR DESCRIPTION
Sometimes on poor connections I'm experiencing Thread pool deadlock, it seems like EndRead in SSL stream waits forever. Hope this will improve situation. I have seen similar problem with connect also.

Try/catch around Dispose was necessary on iOS with Xamarin, if stream was already Disposed (app went foreground), Dispose crashed app with exception.

```
"Threadpool worker" tid=0x0xa4767430 this=0x0xaaf8e950 thread handle 0x578 state : waiting on 0x60e : Sem owns ()
at <unknown> <0xffffffff>
at (wrapper managed-to-native) System.Threading.Monitor.Enter (object) <0xffffffff>
at WebSocketSharp.WebSocket.close (WebSocketSharp.CloseEventArgs,bool,bool,bool) <0x00047>
at (wrapper runtime-invoke) <Module>.runtime_invoke_void__this___object_byte_byte_byte (object,intptr,intptr,intptr) <0xffffffff>


"Threadpool worker" tid=0x0xa84ff430 this=0x0xaba6bd40 thread handle 0x6f8 state : waiting on 0x72a : Event owns ()
at <unknown> <0xffffffff>
at (wrapper managed-to-native) System.Threading.WaitHandle.WaitOne_internal (System.Threading.WaitHandle,intptr,int,bool) <0xffffffff>
at System.Threading.WaitHandle.WaitOne () <0x0006f>
at Mono.Security.Protocol.Tls.RecordProtocol.EndReceiveRecord (System.IAsyncResult) <0x0008b>
at Mono.Security.Protocol.Tls.RecordProtocol.ReceiveRecord (System.IO.Stream) <0x0002f>
at Mono.Security.Protocol.Tls.SslClientStream.SafeReceiveRecord (System.IO.Stream,bool) <0x0002b>
at Mono.Security.Protocol.Tls.SslClientStream.OnNegotiateHandshakeCallback (System.IAsyncResult) <0x00037>
at Mono.Security.Protocol.Tls.SslStreamBase.AsyncHandshakeCallback (System.IAsyncResult) <0x0009f>
at (wrapper runtime-invoke) <Module>.runtime_invoke_void__this___object (object,intptr,intptr,intptr) <0xffffffff>


"Threadpool worker" tid=0x0xa60ff430 this=0x0xaba687a0 thread handle 0xbe7 state : waiting on 0xbe8 : Event owns ()
at <unknown> <0xffffffff>
at (wrapper managed-to-native) System.Threading.WaitHandle.WaitOne_internal (System.Threading.WaitHandle,intptr,int,bool) <0xffffffff>
at System.Threading.WaitHandle.WaitOne () <0x0006f>
at Mono.Security.Protocol.Tls.RecordProtocol.EndReceiveRecord (System.IAsyncResult) <0x0008b>
at Mono.Security.Protocol.Tls.RecordProtocol.ReceiveRecord (System.IO.Stream) <0x0002f>
at Mono.Security.Protocol.Tls.SslClientStream.SafeReceiveRecord (System.IO.Stream,bool) <0x0002b>
at Mono.Security.Protocol.Tls.SslClientStream.OnNegotiateHandshakeCallback (System.IAsyncResult) <0x00037>
at Mono.Security.Protocol.Tls.SslStreamBase.AsyncHandshakeCallback (System.IAsyncResult) <0x0009f>
at (wrapper runtime-invoke) <Module>.runtime_invoke_void__this___object (object,intptr,intptr,intptr) <0xffffffff>


"Threadpool worker" tid=0x0xaa9ff430 this=0x0xaf662c10 thread handle 0x84e state : waiting on 0x8d0 : Event owns ()
at <unknown> <0xffffffff>
at (wrapper managed-to-native) System.Threading.WaitHandle.WaitOne_internal (System.Threading.WaitHandle,intptr,int,bool) <0xffffffff>
at System.Threading.WaitHandle.WaitOne () <0x0006f>
at Mono.Security.Protocol.Tls.SslStreamBase.EndRead (System.IAsyncResult) <0x0009f>
at System.Net.Security.SslStream.EndAuthenticateAsClient (System.IAsyncResult) <0x00047>
at System.Net.Security.SslStream.AuthenticateAsClient (string,System.Security.Cryptography.X509Certificates.X509CertificateCollection,System.Security.Authentication.SslProtocols,bool) <0x0006b>
at WebSocketSharp.WebSocket.setClientStream () <0x002e7>
at WebSocketSharp.WebSocket.doHandshake () <0x0001b>
at WebSocketSharp.WebSocket.connect () <0x000db>
at (wrapper runtime-invoke) <Module>.runtime_invoke_bool__this__ (object,intptr,intptr,intptr) <0xffffffff>


"Threadpool worker" tid=0x0xa97ff430 this=0x0xaba68b10 thread handle 0xadc state : waiting on 0xae8 : Event owns ()
at <unknown> <0xffffffff>
at (wrapper managed-to-native) System.Threading.WaitHandle.WaitOne_internal (System.Threading.WaitHandle,intptr,int,bool) <0xffffffff>
at System.Threading.WaitHandle.WaitOne () <0x0006f>
at Mono.Security.Protocol.Tls.SslStreamBase.EndRead (System.IAsyncResult) <0x0009f>
at System.Net.Security.SslStream.EndAuthenticateAsClient (System.IAsyncResult) <0x00047>
at System.Net.Security.SslStream.AuthenticateAsClient (string,System.Security.Cryptography.X509Certificates.X509CertificateCollection,System.Security.Authentication.SslProtocols,bool) <0x0006b>
at WebSocketSharp.WebSocket.setClientStream () <0x002e7>
at WebSocketSharp.WebSocket.doHandshake () <0x0001b>
at WebSocketSharp.WebSocket.connect () <0x000db>
at (wrapper runtime-invoke) <Module>.runtime_invoke_bool__this__ (object,intptr,intptr,intptr) <0xffffffff>

```