### PR TITLE
Added bandwidth throttling to the websocket stream

### DIFF
--- a/websocket-sharp/ThrottledStream.cs
+++ b/websocket-sharp/ThrottledStream.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+
+namespace WebSocketSharp {
+
+	public class ThrottledStream : Stream {
+
+		/// <summary>
+		/// Actual base stream the data is passed to
+		/// </summary>
+		private Stream _objStream;
+
+		/// <summary>
+		/// Maximum number of bytes per second that's being allowed
+		/// 0 = infinite
+		/// </summary>
+		private long _lngMaxBytesPerSecond = 0;
+		
+		/// <summary>
+		/// Global byte counter used to calculate the current speed (in combination with _lngStartTime)
+		/// </summary>
+		private long _lngByteCount;
+
+		/// <summary>
+		/// Start time the current speed is being calculated on (in combination with _lngByteCount)
+		/// </summary>
+		private long _lngStartTime;
+
+		#region Constructors
+		/// <summary>
+		/// Creates the stream without any bandwidth throttling
+		/// </summary>
+		/// <param name="pStream"></param>
+		public ThrottledStream(Stream pStream) : this(pStream, 0) { }
+
+		/// <summary>
+		/// Creates the stream with the given maximum bytes per second
+		/// </summary>
+		/// <param name="pStream"></param>
+		/// <param name="pBytesPerSecond"></param>
+		public ThrottledStream(Stream pStream, long pBytesPerSecond) {
+			_objStream = pStream;
+			_lngMaxBytesPerSecond = pBytesPerSecond;
+			_lngByteCount = 0;
+			_lngStartTime = Environment.TickCount;
+		}
+		#endregion
+
+		#region Public Properties
+		/// <summary>
+		/// Maximum number of bytes per second allowed to be sent
+		/// </summary>
+		public long MaxBytesPerSecond {
+			get { return _lngMaxBytesPerSecond; }
+			set {
+				if (value < 0) { _lngMaxBytesPerSecond = 0; }
+				_lngMaxBytesPerSecond = value;
+				Reset(); // -- reset current counter
+			}
+		}
+
+		/// <summary>
+		/// Current bytes per second being sent over the stream
+		/// </summary>
+		public long CurrentBytesPerSecond {
+			get { return (_lngByteCount * 1000L) / (Environment.TickCount - _lngStartTime); }
+		}
+		#endregion
+
+		#region Stream Overrides
+		public override bool CanRead { get { return _objStream.CanRead; } }
+		public override bool CanSeek { get { return _objStream.CanSeek; } }
+		public override bool CanWrite { get { return _objStream.CanWrite; } }
+		public override long Length { get { return _objStream.Length; } }
+		public override void Flush() { _objStream.Flush(); }
+		public override long Position {
+			get { return _objStream.Position; }
+			set { _objStream.Position = value; }
+		}
+		public override long Seek(long pOffset, SeekOrigin pOrigin) {
+			return _objStream.Seek(pOffset, pOrigin);
+		}
+		public override void SetLength(long value) {
+			_objStream.SetLength(value);
+		}
+		public override string ToString() {
+			return _objStream.ToString();
+		}
+		public override int Read(byte[] pBuffer, int pOffset, int pCount) {
+			WaitIfNeeded(pCount);
+			return _objStream.Read(pBuffer, pOffset, pCount);
+		}
+		public override void Write(byte[] buffer, int offset, int count) {
+			WaitIfNeeded(count);
+			_objStream.Write(buffer, offset, count);
+		}
+		#endregion
+
+		/// <summary>
+		/// Slows down sending the bytes if needed
+		/// </summary>
+		/// <param name="pByteCount"></param>
+		private void WaitIfNeeded(int pByteCount) {
+			if(_lngMaxBytesPerSecond == 0) { return; } // -- no limit
+			if (pByteCount == 0) { return; } // -- nothing to write, so no waiting
+
+			//update global byte counter
+			_lngByteCount += pByteCount;
+
+			var lngTimePassed = Environment.TickCount - _lngStartTime;
+			if (lngTimePassed > 0) {
+				var lngCurrentSpeed = _lngByteCount * 1000L / lngTimePassed;
+				if (lngCurrentSpeed > _lngMaxBytesPerSecond) { // -- do we need to wait?
+					var intMilisecondsToSleep = ((_lngByteCount * 1000L / _lngMaxBytesPerSecond) - lngTimePassed);
+					if (intMilisecondsToSleep > 1) {
+						try {
+							Thread.Sleep((int)intMilisecondsToSleep);
+						} catch (Exception) { } // can happen when threads get killed/aborted
+						Reset();
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Reset the timer being used to throttle the speed
+		/// </summary>
+		protected void Reset() {
+			//To better shape the stream, keep 10 second history
+			if ((Environment.TickCount - _lngStartTime) > 10000) {
+				_lngByteCount = 0;
+				_lngStartTime = Environment.TickCount;
+			}
+		}
+	}
+}

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -114,7 +114,7 @@ namespace WebSocketSharp
     private int                            _retryCountForConnect;
     private bool                           _secure;
     private ClientSslConfiguration         _sslConfig;
-    private Stream                         _stream;
+    private ThrottledStream          _stream;
     private TcpClient                      _tcpClient;
     private Uri                            _uri;
     private const string                   _version = "13";
@@ -174,7 +174,7 @@ namespace WebSocketSharp
       _logger = context.Log;
       _message = messages;
       _secure = context.IsSecureConnection;
-      _stream = context.Stream;
+      _stream = new ThrottledStream(context.Stream, MaxBytesPerSecond);
       _waitTime = TimeSpan.FromSeconds (1);
 
       init ();
@@ -190,7 +190,7 @@ namespace WebSocketSharp
       _logger = context.Log;
       _message = messages;
       _secure = context.IsSecureConnection;
-      _stream = context.Stream;
+      _stream = new ThrottledStream(context.Stream, MaxBytesPerSecond);
       _waitTime = TimeSpan.FromSeconds (1);
 
       init ();
@@ -773,6 +773,24 @@ namespace WebSocketSharp
         }
       }
     }
+
+	/// <summary>
+	/// Gets or sets the maxiumum bytes per second
+	/// </summary>
+	/// <value>
+	/// long representing the maximum number of bytes/second
+	/// 0 or lower is infinite
+	/// </value>
+	public long MaxBytesPerSecond { get; set; } = 0;
+
+	public long CurrentBytesPerSecond {
+		get {
+			if (_stream != null) {
+					return _stream.CurrentBytesPerSecond;
+			}
+			return 0;
+		}
+	}
 
     #endregion
 
@@ -2094,7 +2112,7 @@ namespace WebSocketSharp
           if (res.HasConnectionClose) {
             releaseClientResources ();
             _tcpClient = new TcpClient (_proxyUri.DnsSafeHost, _proxyUri.Port);
-            _stream = _tcpClient.GetStream ();
+            _stream = new ThrottledStream(_tcpClient.GetStream (), MaxBytesPerSecond);
           }
 
           var authRes = new AuthenticationResponse (authChal, _proxyCredentials, 0);
@@ -2116,12 +2134,12 @@ namespace WebSocketSharp
     {
       if (_proxyUri != null) {
         _tcpClient = new TcpClient (_proxyUri.DnsSafeHost, _proxyUri.Port);
-        _stream = _tcpClient.GetStream ();
+        _stream = new ThrottledStream(_tcpClient.GetStream (), MaxBytesPerSecond);
         sendProxyConnectRequest ();
       }
       else {
         _tcpClient = new TcpClient (_uri.DnsSafeHost, _uri.Port);
-        _stream = _tcpClient.GetStream ();
+        _stream = new ThrottledStream(_tcpClient.GetStream (), MaxBytesPerSecond);
       }
 
       if (_secure) {
@@ -2144,7 +2162,7 @@ namespace WebSocketSharp
             conf.EnabledSslProtocols,
             conf.CheckCertificateRevocation);
 
-          _stream = sslStream;
+          _stream = new ThrottledStream(sslStream, MaxBytesPerSecond);
         }
         catch (Exception ex) {
           throw new WebSocketException (CloseStatusCode.TlsHandshakeFailure, ex);

--- a/websocket-sharp/websocket-sharp.csproj
+++ b/websocket-sharp/websocket-sharp.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Net\HttpHeaderInfo.cs" />
     <Compile Include="CompressionMethod.cs" />
     <Compile Include="WebSocketException.cs" />
+    <Compile Include="ThrottledStream.cs" />
     <Compile Include="LogData.cs" />
     <Compile Include="LogLevel.cs" />
     <Compile Include="Logger.cs" />


### PR DESCRIPTION
For a project I needed to send larger amounts of data and needed the ability to throttle it to a user defined amount.

Added a ThrottledStream class that just wait if the bytes/sec is going over the set limit.
Profiling showed no performance impact, also kept it to 2 simple properties, one to set the maximum bytes/sec and one to get the current bytes/sec.