### PR TITLE
Made FragmentLength property public

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -141,7 +141,7 @@ namespace WebSocketSharp
     ///   <c>Int32.MaxValue - 14</c> inclusive.
     ///   </para>
     /// </remarks>
-    internal static readonly int FragmentLength;
+    public static int FragmentLength { get; set; }
 
     /// <summary>
     /// Represents the random number generator used internally.


### PR DESCRIPTION
Made the FragmentLength property public so that someone using the WebSocketSharp library doesn't need to modify & recompile the source.

This is sometimes needed when sending larger amounts of data over the connection, 1kb is too small and has a performance impact. 

Ideal is actually 256kb fragments for large transfers, anything higher and there is no real benefit, anything lower takes more CPU & the throughput drops.