### PR TITLE
Allow OS to choose the best protocol to use

### DIFF
--- a/websocket-sharp/Net/ClientSslConfiguration.cs
+++ b/websocket-sharp/Net/ClientSslConfiguration.cs
@@ -64,7 +64,7 @@ namespace WebSocketSharp.Net
     /// </summary>
     public ClientSslConfiguration ()
     {
-      _enabledSslProtocols = SslProtocols.Default;
+      _enabledSslProtocols = SslProtocols.None;
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ namespace WebSocketSharp.Net
     public ClientSslConfiguration (string targetHost)
     {
       _targetHost = targetHost;
-      _enabledSslProtocols = SslProtocols.Default;
+      _enabledSslProtocols = SslProtocols.None;
     }
 
     /// <summary>


### PR DESCRIPTION
As per documentation (https://docs.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=netframework-4.8), `None` should be used as default value, not `Default`, because `Default` allows only outdated and less secure protocols.