### PR TITLE
CookieException: implement ISerializable

### DIFF
--- a/websocket-sharp/Net/CookieException.cs
+++ b/websocket-sharp/Net/CookieException.cs
@@ -46,7 +46,7 @@ namespace WebSocketSharp.Net
   /// The exception that is thrown when a <see cref="Cookie"/> gets an error.
   /// </summary>
   [Serializable]
-  public class CookieException : FormatException
+  public class CookieException : FormatException, ISerializable
   {
     #region Internal Constructors
 


### PR DESCRIPTION
It will fix the following compilation error:
`Net/CookieException.cs(156,10): error CS0540: 'CookieException.ISerializable.GetObjectData(SerializationInfo, StreamingContext)': containing type does not implement interface 'ISerializable' [.../websocket-sharp/websocket-sharp/websocket-sharp.csproj]`