### PR TITLE
In closeHandshake do not mask the payload when receiving. Fixes issue #360

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -1201,10 +1201,10 @@ namespace WebSocketSharp
     {
       var sent = false;
       if (send) {
-        var frame = WebSocketFrame.CreateCloseFrame (payloadData, _client);
+        var frame = WebSocketFrame.CreateCloseFrame (payloadData, _client && !received);
         sent = sendBytes (frame.ToArray ());
 
-        if (_client)
+        if (_client && !received)
           frame.Unmask ();
       }
 


### PR DESCRIPTION
It seems that the closeHandshake method masks the payload even when receiving. This leads to garbage in the Reason property of CloseEventArgs.