### PR TITLE
add_http_response_code_and_body_when_handshake_error

### DIFF
--- a/websocket-sharp/CloseEventArgs.cs
+++ b/websocket-sharp/CloseEventArgs.cs
@@ -101,6 +101,28 @@ namespace WebSocketSharp
     }
 
     /// <summary>
+    /// Gets the http status code for the handshake error
+    /// </summary>
+    /// <value>
+    ///   <para>
+    ///   A <see cref="int"/> that represents http status code for
+    ///   the handshake error
+    ///   </para>
+    /// </value>
+    public int HttpStatusCode => _payloadData.HttpStatusCode;
+   
+    /// <summary>
+    /// Gets the http response body for the handshake error
+    /// </summary>
+    /// <value>
+    ///   <para>
+    ///   A <see cref="int"/> that represents http response body for
+    ///   the handshake error
+    ///   </para>
+    /// </value>
+    public string HttpResponseBody => _payloadData.HttpResponseBody;
+    
+    /// <summary>
     /// Gets a value indicating whether the connection has been closed cleanly.
     /// </summary>
     /// <value>

--- a/websocket-sharp/PayloadData.cs
+++ b/websocket-sharp/PayloadData.cs
@@ -95,11 +95,24 @@ namespace WebSocketSharp
       _data = code.Append (reason);
       _length = _data.LongLength;
     }
+    
+    internal PayloadData (ushort code, string reason, int httpStatusCode, string httpResponseBody)
+    {
+      _data = code.Append (reason);
+      _length = _data.LongLength;
+      HttpStatusCode = httpStatusCode;
+      HttpResponseBody = httpResponseBody;
+
+    }
 
     #endregion
 
     #region Internal Properties
 
+    internal int HttpStatusCode { get; }
+    
+    internal string HttpResponseBody { get; }
+    
     internal ushort Code {
       get {
         return _length >= 2

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -797,6 +797,13 @@ namespace WebSocketSharp
       close (data, false, false);
     }
 
+    private void abort(ushort code, string reason, int httpStatusCode, string httpResponseBody)
+    {
+      var data = new PayloadData(code, reason, httpStatusCode, httpResponseBody);
+    
+      close(data, false, false);
+    }
+    
     // As server
     private bool accept ()
     {
@@ -1507,7 +1514,7 @@ namespace WebSocketSharp
         _log.Error (msg);
         _log.Debug (res.ToString ());
 
-        abort (1002, "A handshake error has occurred.");
+        abort (1002, "A handshake error has occurred.", res.StatusCode, res.MessageBody);
 
         return false;
       }


### PR DESCRIPTION
When a handshake error occurs, it is helpful if you can receive the http response code and body in the onclose event.