### PR TITLE
 error CS0103: The name 'QueryString' does not exist in the current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ public class Chat : WebSocketBehavior
 
   protected override void OnOpen ()
   {
-    _name = QueryString["name"];
+    _name = Context.QueryString["name"];
   }
 
   ...


### PR DESCRIPTION
Readme.md: append Context. to QueryString example